### PR TITLE
Set fallback theme before page load

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,11 +1,13 @@
 import Document, {
-  Html,
+  DocumentContext,
+  DocumentInitialProps,
   Head,
+  Html,
   Main,
   NextScript,
-  DocumentInitialProps,
-  DocumentContext,
 } from "next/document";
+import { themes } from "../types/Themes";
+import { getFallbackTheme } from "../utils/theme-utils";
 
 class CustomDocument extends Document {
   static host: string;
@@ -70,7 +72,7 @@ class CustomDocument extends Document {
     return (
       <Html lang="nb">
         <Head>{CustomDocument.renderHead()}</Head>
-        <body>
+        <body data-theme={getFallbackTheme(themes)}>
           {process.env.NODE_ENV === "production" && CustomDocument.renderGTM()}
           <Main />
           <NextScript />

--- a/src/utils/theme-utils.ts
+++ b/src/utils/theme-utils.ts
@@ -14,11 +14,14 @@ export function getTheme(themeName: string, themes: readonly Theme[]): Theme {
   return theme;
 }
 
-export function getActiveTheme(themes: readonly Theme[]): Theme {
+export function getFallbackTheme(themes: ReadonlyArray<Theme>): Theme {
+  return themes.find(theme => theme.name === "pride") ?? themes[0];
+}
+
+export function getActiveTheme(themes: ReadonlyArray<Theme>): Theme {
   const activeThemeName = window.localStorage.getItem("active-theme");
 
-  const fallbackTheme =
-    themes.find(theme => theme.name === "pride") ?? themes[0];
+  const fallbackTheme = getFallbackTheme(themes);
 
   return activeThemeName ? getTheme(activeThemeName, themes) : fallbackTheme;
 }


### PR DESCRIPTION
By doing this, a theme is already set when the page loads. It is likely
that the user will use the default theme, and this will trick Lighthouse
and search engines into believing that there are fewer cumulative page
shifts.