### PR TITLE
chore: install separate puppeteer-core version for vercel functions

### DIFF
--- a/api/get-social-media-preview-image.ts
+++ b/api/get-social-media-preview-image.ts
@@ -6,7 +6,7 @@ import type {
   BrowserLaunchArgumentOptions,
   LaunchOptions,
 } from "puppeteer-core";
-import { launch as launchCore } from "puppeteer-core";
+import { launch as launchCore } from "puppeteer-core14";
 
 function getExecutablePath(): string {
   let exePath = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "lz-string": "^1.4.4",
         "next": "^12.3.1",
         "puppeteer": "^15.5.0",
-        "puppeteer-core": "^14.4.1",
+        "puppeteer-core": "^15.5.0",
+        "puppeteer-core14": "npm:puppeteer-core@^14.4.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -13434,6 +13435,49 @@
       }
     },
     "node_modules/puppeteer-core": {
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-15.5.0.tgz",
+      "integrity": "sha512-5Q8EmF++MARczJD1JcRehVePlctxGG2TFHSxdCV8NqPOk44/cMySmZw2nETn+lwUOyp0L9afosMFTnT4KgmWgw==",
+      "dependencies": {
+        "cross-fetch": "3.1.5",
+        "debug": "4.3.4",
+        "devtools-protocol": "0.0.1019158",
+        "extract-zip": "2.0.1",
+        "https-proxy-agent": "5.0.1",
+        "pkg-dir": "4.2.0",
+        "progress": "2.0.3",
+        "proxy-from-env": "1.1.0",
+        "rimraf": "3.0.2",
+        "tar-fs": "2.1.1",
+        "unbzip2-stream": "1.4.3",
+        "ws": "8.8.0"
+      },
+      "engines": {
+        "node": ">=14.1.0"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/ws": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-core14": {
+      "name": "puppeteer-core",
       "version": "14.4.1",
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-14.4.1.tgz",
       "integrity": "sha512-ykeQf8vAFVziQWsGu0AQ782KZgFlcQS/wDwbBJuKyR7zdb+rIKEBLpyeE46KUhbw/TjNyhb7MPFb/qrO9xIs0A==",
@@ -13455,12 +13499,12 @@
         "node": ">=14.1.0"
       }
     },
-    "node_modules/puppeteer-core/node_modules/devtools-protocol": {
+    "node_modules/puppeteer-core14/node_modules/devtools-protocol": {
       "version": "0.0.1001819",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1001819.tgz",
       "integrity": "sha512-G6OsIFnv/rDyxSqBa2lDLR6thp9oJioLsb2Gl+LbQlyoA9/OBAkrTU9jiCcQ8Pnh7z4d6slDiLaogR5hzgJLmQ=="
     },
-    "node_modules/puppeteer-core/node_modules/ws": {
+    "node_modules/puppeteer-core14/node_modules/ws": {
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
       "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
@@ -25039,7 +25083,34 @@
       }
     },
     "puppeteer-core": {
-      "version": "14.4.1",
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-15.5.0.tgz",
+      "integrity": "sha512-5Q8EmF++MARczJD1JcRehVePlctxGG2TFHSxdCV8NqPOk44/cMySmZw2nETn+lwUOyp0L9afosMFTnT4KgmWgw==",
+      "requires": {
+        "cross-fetch": "3.1.5",
+        "debug": "4.3.4",
+        "devtools-protocol": "0.0.1019158",
+        "extract-zip": "2.0.1",
+        "https-proxy-agent": "5.0.1",
+        "pkg-dir": "4.2.0",
+        "progress": "2.0.3",
+        "proxy-from-env": "1.1.0",
+        "rimraf": "3.0.2",
+        "tar-fs": "2.1.1",
+        "unbzip2-stream": "1.4.3",
+        "ws": "8.8.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+          "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
+          "requires": {}
+        }
+      }
+    },
+    "puppeteer-core14": {
+      "version": "npm:puppeteer-core@14.4.1",
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-14.4.1.tgz",
       "integrity": "sha512-ykeQf8vAFVziQWsGu0AQ782KZgFlcQS/wDwbBJuKyR7zdb+rIKEBLpyeE46KUhbw/TjNyhb7MPFb/qrO9xIs0A==",
       "requires": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "lz-string": "^1.4.4",
     "next": "^12.3.1",
     "puppeteer": "^15.5.0",
-    "puppeteer-core": "^14.4.1",
+    "puppeteer-core": "^15.5.0",
+    "puppeteer-core14": "npm:puppeteer-core@^14.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
Functions in Vercel cannot be larger than 50MB, which v15 of @sparticuz/chrome-aws-lambda is, while v14 just about isn't.